### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Awesome resources for serial communication using the browser. Includes these ver
 
 ## Code utilities
 
-- [fromWebSerial](https://rxjs.ninja/modules/utility.html#fromwebserial) - RxJS Ninja utility function that returns the serial read data as an Observable, and can also receive an Observable to use as a write stream.
+- [fromWebSerial](https://rxjs-ninja.tane.dev/modules/utility.html#fromwebserial) - RxJS Ninja utility function that returns the serial read data as an Observable, and can also receive an Observable to use as a write stream.
+- 
 
 ## Documentation / Implementation / Tutorials
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [ ] I've added the new resource at the end of its section.
- [ ] This resource is actively maintained.

---

I noticed the link for the rxjs fromWebSerial is dead, looks like it moved to a new TLD. This PR fixes the link
