### PR TITLE
Add modbus-webserial to Code utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Awesome resources for serial communication using the browser. Includes these ver
 
 - [fromWebSerial](https://rxjs-ninja.tane.dev/modules/utility.html#fromwebserial) - RxJS Ninja utility function that returns the serial read data as an Observable, and can also receive an Observable to use as a write stream.
 - [SimpleWebSerial](https://fmgrafikdesign.gitbook.io/simplewebserial/) - Easy-to-use library that allows web enthusiasts to easily connect an Arduino with their web project. Employs an event-driven coding style.
+- [modbus-webserial](https://github.com/anttikotajarvi/modbus-webserial) - ES library for communicating with a Modbus-RTU serial device from the browser via WebSerial.
 
 ## Documentation / Implementation / Tutorials
 


### PR DESCRIPTION
Add modbus-webserial to Code utilities

<!-- Thank you for your interest in Awesome Web Serial -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is actively maintained.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->
Adds modbus-webserial, a small TypeScript library that lets web apps speak Modbus-RTU over the Web Serial API. It exposes a minimal, promise-based client for reading/writing coils and registers from the browser. 
Fits under Code utilities alongside other developer-facing libs.
...
